### PR TITLE
Fix aria attribute typo in layout

### DIFF
--- a/Pages/Shared/_Layout.cshtml
+++ b/Pages/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
                             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 @Thread.CurrentThread.CurrentUICulture.Name
                             </a>
-                            <ul class="dropdown-menu" aria-labelleby="navbarDropdown">
+                            <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
                                 <li><a class="dropdown-item" href="/Lang?culture=en">en</a></li>
                                 <li><a class="dropdown-item" href="/Lang?culture=it">it</a></li>
                             </ul>


### PR DESCRIPTION
## Summary
- fix typo in `_Layout.cshtml` dropdown menu (`aria-labelleby` -> `aria-labelledby`)

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d13412b0832aa4ddbd77b66fc844