### PR TITLE
Update README with setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-Web Application Front-End for the project MULTICLIMACT
-2024-11-18
+# MultiClimact Front-End
+
+ASP.NET Core web interface for the **MULTICLIMACT** project.
+
+## Prerequisites
+
+- [.NET SDK 8.0](https://dotnet.microsoft.com/download) or later
+- Access to a PostgreSQL database instance
+
+## Building and running
+
+1. Restore and build the solution:
+
+   ```bash
+   dotnet build
+   ```
+
+2. Apply database migrations if required:
+
+   ```bash
+   dotnet ef database update
+   ```
+
+3. Run the development server:
+
+   ```bash
+   dotnet run
+   ```
+
+The application will start on `https://localhost:5001` by default.
+
+## Configuration
+
+Application settings are defined in `appsettings.json`. Important options are:
+
+- `ConnectionStrings:DefaultConnection` – PostgreSQL connection string.
+- `earthquakeSimulationServiceUrl` – endpoint for submitting earthquake simulations.
+- `earthquakeTodayBaseAddress` and `earthquakeTodayAPIUrl` – base address and path for obtaining earthquake data.
+- `wms` – URLs and layer names for WMS geospatial services.
+
+Environment specific files such as `appsettings.Development.json` can override these settings.
+


### PR DESCRIPTION
## Summary
- expand README with .NET prerequisites and build/run steps
- document configuration options for connection strings and external service URLs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3d78bb60832ab70dbef05d43f9d0